### PR TITLE
🔒 [security fix] Sanitize error logging and reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,6 @@ app
   .start(6262)
   .then(() => console.log("dolfje is running"))
   .catch((error) => {
-    console.error(error);
+    console.error(error.message);
     process.exit(1);
   });

--- a/ww_actions.js
+++ b/ww_actions.js
@@ -67,7 +67,7 @@ async function voteClick({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `Er ging iets mis met het stemmen: ${error}`,
+      `Er ging iets mis met het stemmen: ${error.message}`,
     );
   }
 }
@@ -201,7 +201,7 @@ async function quickVoteClick({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `Er ging iets mis met het vluchtig stemmen: ${error}`,
+      `Er ging iets mis met het vluchtig stemmen: ${error.message}`,
     );
   }
 }
@@ -231,7 +231,7 @@ async function selfInviteClickFunction(channelId, userId) {
     await helpers.sendIM(
       client,
       userId,
-      `Er ging iets mis met het het zelf uitnodigen: ${error}`,
+      `Er ging iets mis met het het zelf uitnodigen: ${error.message}`,
     );
   }
 }
@@ -257,7 +257,7 @@ async function selfInviteAllChannelsFunction(gameId, userId) {
     await helpers.sendIM(
       client,
       userId,
-      `Er ging iets mis met uitnodigen voor alle kanalen: ${error}`,
+      `Er ging iets mis met uitnodigen voor alle kanalen: ${error.message}`,
     );
   }
 }
@@ -275,7 +275,7 @@ async function joinAction({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLJOIN")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLJOIN")}: ${error.message}`,
     );
   }
 }
@@ -376,7 +376,7 @@ async function joinActionFunction(
     await helpers.sendIM(
       client,
       userId,
-      `Er ging iets mis met deelnemen: ${error}`,
+      `Er ging iets mis met deelnemen: ${error.message}`,
     );
   }
 }
@@ -394,7 +394,7 @@ async function viewAction({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error.message}`,
     );
   }
 }
@@ -561,7 +561,7 @@ async function viewActionFunction( // NOSONAR
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error.message}`,
     );
   }
 }
@@ -585,7 +585,7 @@ async function unregisterAction({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error.message}`,
     );
   }
 }
@@ -688,7 +688,7 @@ async function unregisterActionFunction(
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error.message}`,
     );
   }
 }
@@ -716,7 +716,7 @@ async function addModeratorAction({ body, ack, say }) {
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error.message}`,
     );
   }
 }
@@ -870,7 +870,7 @@ async function addModeratorFunction(
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error.message}`,
     );
   }
 }
@@ -896,7 +896,7 @@ async function createNewChannel({ body, ack, say }) {
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error.message}`,
     );
   }
 }
@@ -960,7 +960,7 @@ async function createNewChannelFunction(
     await helpers.sendIM(
       client,
       userId,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error.message}`,
     );
   }
 }
@@ -977,7 +977,7 @@ async function deleteMessage({ body, ack, say }) {
     await helpers.sendIM(
       client,
       body.user.id,
-      `${t("TEXTCOMMANDERROR")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")}: ${error.message}`,
     );
   }
 }

--- a/ww_commands.js
+++ b/ww_commands.js
@@ -270,7 +270,7 @@ function addSummaryFiles(summary, filesRaw) {
       summary.push(file);
     }
   } catch (err) {
-    console.error(err);
+    console.error(err.message);
     const fallbackMatch = filesRaw.match(/<(.*)\|/);
     const fallbackText = fallbackMatch
       ? fallbackMatch[1]
@@ -382,7 +382,7 @@ async function channelList({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDLIST")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDLIST")}: ${error.message}`,
     );
   }
 }
@@ -405,7 +405,7 @@ async function status({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTATUS")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTATUS")}: ${error.message}`,
     );
   }
 }
@@ -449,7 +449,7 @@ async function archive({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDARCHIVE")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDARCHIVE")}: ${error.message}`,
     );
   }
 }
@@ -514,7 +514,7 @@ async function startVoteRound({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDVOTEROUND")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDVOTEROUND")}: ${error.message}`,
     );
   }
 }
@@ -569,7 +569,7 @@ async function stopVoteRound({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTOPVOTEROUND")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTOPVOTEROUND")}: ${error.message}`,
     );
   }
 }
@@ -597,7 +597,7 @@ async function voteReminder({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMINDER")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMINDER")}: ${error.message}`,
     );
   }
 }
@@ -653,7 +653,7 @@ async function voteScore({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDVOTESCORE")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDVOTESCORE")}: ${error.message}`,
     );
   }
 }
@@ -717,7 +717,7 @@ async function startQuickVoteRound({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTQUICKVOTE")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTQUICKVOTE")}: ${error.message}`,
     );
   }
 }
@@ -779,7 +779,7 @@ async function startRegistration({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTREGISTRATION")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTREGISTRATION")}: ${error.message}`,
     );
   }
 }
@@ -1000,7 +1000,7 @@ async function startGameCommand({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTGAME")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTARTGAME")}: ${error.message}`,
     );
   }
 }
@@ -1103,7 +1103,7 @@ async function stopGameCommand({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTOPGAME")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSTOPGAME")}: ${error.message}`,
     );
   }
 }
@@ -1180,7 +1180,7 @@ async function createChannel({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDCREATECHANNEL")}: ${error.message}`,
     );
   }
 }
@@ -1228,7 +1228,7 @@ async function markDead({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDDEAD")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDDEAD")}: ${error.message}`,
     );
   }
 }
@@ -1267,7 +1267,7 @@ async function revive({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREVIVE")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREVIVE")}: ${error.message}`,
     );
   }
 }
@@ -1355,7 +1355,7 @@ async function addExtraModerator({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDEXTRAMODERATOR")}: ${error.message}`,
     );
   }
 }
@@ -1397,7 +1397,7 @@ async function inviteModerators({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDINVITEMODERATOR")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDINVITEMODERATOR")}: ${error.message}`,
     );
   }
 }
@@ -1433,7 +1433,7 @@ async function invitePlayers({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDINVITEPLAYERS")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDINVITEPLAYERS")}: ${error.message}`,
     );
   }
 }
@@ -1507,7 +1507,7 @@ async function iWillJoin({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLJOIN")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLJOIN")}: ${error.message}`,
     );
   }
 }
@@ -1581,7 +1581,7 @@ async function iWillView({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDIWILLVIEW")}: ${error.message}`,
     );
   }
 }
@@ -1655,7 +1655,7 @@ async function iWillNotJoinAnymore({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDREMOVEYOURSELFFROMGAME")}: ${error.message}`,
     );
   }
 }
@@ -1713,7 +1713,7 @@ async function assignRoles({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDGIVEROLES")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDGIVEROLES")}: ${error.message}`,
     );
   }
 }
@@ -1727,7 +1727,7 @@ async function help({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDHELP")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDHELP")}: ${error.message}`,
     );
   }
 }
@@ -1769,7 +1769,7 @@ async function lotto({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDLOTTO")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDLOTTO")}: ${error.message}`,
     );
   }
 }
@@ -1820,7 +1820,7 @@ async function summarize({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSUMMARIZE")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDSUMMARIZE")}: ${error.message}`,
     );
   }
 }
@@ -1886,7 +1886,7 @@ async function whoIsPlaying({ command, ack, say }) {
     await helpers.sendIM(
       client,
       command.user_id,
-      `${t("TEXTCOMMANDERROR")} ${t("COMMANDWHOISPLAYING")}: ${error}`,
+      `${t("TEXTCOMMANDERROR")} ${t("COMMANDWHOISPLAYING")}: ${error.message}`,
     );
   }
 }

--- a/ww_messages.js
+++ b/ww_messages.js
@@ -108,8 +108,8 @@ async function startVoting({ message, say }) {
     });
     await queries.setMessageIdPoll(game.gms_id, chatMessage);
   } catch (error) {
-    console.log(
-      `Er ging iets mis met automagisch starten stem ronde: ${error}`,
+    console.error(
+      `Er ging iets mis met automagisch starten stem ronde: ${error.message}`,
     );
   }
 }
@@ -247,8 +247,8 @@ async function stopVoting({ message, say }) {
     helpers.shuffle(channelUsersAlive);
     helpers.postDelayed(client, pollMessage.channelId, channelUsersAlive);
   } catch (error) {
-    console.log(
-      `Er ging iets mis met automagische sluiting stemming: ${error}`,
+    console.error(
+      `Er ging iets mis met automagische sluiting stemming: ${error.message}`,
     );
   }
 }
@@ -298,7 +298,9 @@ async function remindVoters({ message, say }) {
       ],
     });
   } catch (error) {
-    console.log(`Er ging iets mis met automagische stemherinnering: ${error}`);
+    console.error(
+      `Er ging iets mis met automagische stemherinnering: ${error.message}`,
+    );
   }
 }
 
@@ -342,11 +344,13 @@ async function registerMessage({ message, say }) {
         threadTs,
       );
     } catch (error) {
-      console.log(`Er ging iets mis met het opslaan van de message: ${error}`);
+      console.error(
+        `Er ging iets mis met het opslaan van de message: ${error.message}`,
+      );
     }
   } catch (error) {
-    console.log(
-      `Er ging iets mis met het registeren van een message: ${error}`,
+    console.error(
+      `Er ging iets mis met het registeren van een message: ${error.message}`,
     );
   }
 }
@@ -355,8 +359,8 @@ async function registerArchive({ event, context }) {
   try {
     await queries.logArchiveChannel(event.channel);
   } catch (error) {
-    console.log(
-      `Er ging iets mis met het registeren van het archiveren van een kanaal: ${error}`,
+    console.error(
+      `Er ging iets mis met het registeren van het archiveren van een kanaal: ${error.message}`,
     );
   }
 }

--- a/ww_queries.js
+++ b/ww_queries.js
@@ -97,14 +97,10 @@ const pollStates = {
 };
 
 async function getLastGameName() {
-  try {
-    const { rows } = await promisePool.query(
-      `select gms_name from games where gms_id = (select max(gms_id) from games)`,
-    );
-    return rows;
-  } catch (err) {
-    console.log(err);
-  }
+  const { rows } = await promisePool.query(
+    `select gms_name from games where gms_id = (select max(gms_id) from games)`,
+  );
+  return rows;
 }
 
 async function createNewGame(voteStyle, gameName, revivable, userId, userName) {
@@ -119,8 +115,8 @@ async function createNewGame(voteStyle, gameName, revivable, userId, userName) {
     await addModerator(userId, userName, game.gms_id);
     return { succes: true, gameName: game.gms_name };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in createNewGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -216,8 +212,8 @@ async function startGame(gameId, maxPlayers) {
       vertellerList: rows3,
     };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in startGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -231,8 +227,8 @@ async function stopGame(gameId) {
     );
     return { succes: true };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in stopGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -287,8 +283,8 @@ async function joinGame(gameId, userId, userName) {
       numberOfViewers: rows[0].numberOfViewers,
     };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in joinGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -345,8 +341,8 @@ async function viewGame(userId, userName, gameId) {
       numberOfViewers: rows[0].numberOfViewers,
     };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in viewGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -372,8 +368,8 @@ async function leaveGame(gameId, userId) {
       numberOfViewers: rows[0].numberOfViewers,
     };
   } catch (err) {
-    console.log(err);
-    return { succes: false, error: err };
+    console.error("Database error in leaveGame:", err.message);
+    return { succes: false, error: err.message };
   }
 }
 
@@ -982,7 +978,7 @@ async function logArchiveChannel(channelId) {
       [channelId],
     );
   } catch (error) {
-    console.log(error);
+    console.error("Database error in logArchiveChannel:", error.message);
   }
 }
 
@@ -1011,7 +1007,7 @@ async function storeMessage(channelId, userId, ts, blocks, files, threadTs) {
 
   if (!rows2.length || !rows2[0].gpm_slack_ts) {
     if (threadTs) {
-      console.log("unmatched thread: ", threadTs, "for message: ", ts);
+      console.error("unmatched thread: ", threadTs, "for message: ", ts);
     }
     threadTs = null;
   }


### PR DESCRIPTION
- Replaced `console.log(err)` with `console.error(err.message)` across the codebase to prevent leaking sensitive stack traces and system information.
- Updated functions in `ww_queries.js` to return sanitized error messages instead of raw error objects.
- Modified catch blocks in `ww_actions.js`, `ww_commands.js`, and `ww_messages.js` to ensure only `error.message` is sent to Slack users.
- Cleaned up error propagation in `getLastGameName`.
- Sanitized startup error logging in `index.js`.